### PR TITLE
Improve sprite initialization for round-tft

### DIFF
--- a/round-tft/src/main.cpp
+++ b/round-tft/src/main.cpp
@@ -188,10 +188,15 @@ void setup() {
   tft.setBrightness(200);
   Serial.println("Brightness set (if supported)");
   canvas.setColorDepth(16);
-  canvas.createSprite(240, 240);
+  if (!canvas.createSprite(240, 240)) {
+    Serial.println("Failed to allocate sprite buffer");
+  }
+  canvas.setSwapBytes(true);
+  canvas.fillScreen(TFT_BLACK);
 
   drawClippingTest();
   Serial.println("Clipping test displayed");
+  tft.clearClipRect();
   delay(3000);  // view clipping test for 3 seconds
   if (DEMO_MODE == DEMO_STARFIELD) {
     initStars();


### PR DESCRIPTION
## Summary
- handle sprite allocation failures
- ensure byte order is correct when using the sprite
- clear clip rect before starting demos

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_684d0c2b5088832b88e447c9ea1fa2bd