### PR TITLE
Add WiFi-enabled clock & temperature mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ After a short clipping test the firmware will run one of several demos:
 - **Plasma** – a colourful swirling plasma effect.
 - **Hybrid clock** – arc clock outer rings with an analogue dial in the centre.
 - **AHT10 sensor** – displays the current temperature and humidity.
+- **Clock with temperature** – syncs time over WiFi and shows sensor readings.
 
 Edit the `DEMO_MODE` constant in `src/main.cpp` to choose which demo is
 displayed.

--- a/round-tft/platformio.ini
+++ b/round-tft/platformio.ini
@@ -14,6 +14,6 @@ board = lolin_s2_mini
 board_build.psram = enabled
 framework = arduino
 lib_deps = \
-  lovyan03/LovyanGFX@^1.1.9 \
-  adafruit/Adafruit AHTX0@^2.0.5
+  lovyan03/LovyanGFX@1.1.9 \
+  adafruit/Adafruit AHTX0@2.0.5
 monitor_speed = 115200


### PR DESCRIPTION
## Summary
- add new DEMO_CLOCK_TEMP mode combining WiFi synced clock with AHT10 sensor
- connect to WiFi and configure NTP timezone (+9.5h)
- show temperature and humidity alongside digital time and progress arcs
- document the new mode

## Testing
- `pio run` *(fails: SemanticVersionError)*

------
https://chatgpt.com/codex/tasks/task_e_684d2bca5364832b89a77d7fe51175d8